### PR TITLE
Add editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+
+[*.{c,h}]
+indent_size = 4
+
+[CMakeLists.txt]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_style = space
 [*.{c,h}]
 indent_size = 4
 
+[*.{cpp,hpp}]
+indent_size = 4
+
 [CMakeLists.txt]
 indent_size = 2


### PR DESCRIPTION
Adds a `.editorconfig` file so that editors consistently enforce at least tab/space styling across all our development platforms.
VS users (@HarounAns  and @nmiller127) should either update to VS 2017RC1 which has built-in support for the editorconfig format or install the EditorConfig extension, available [here](https://marketplace.visualstudio.com/items?itemName=EditorConfigTeam.EditorConfig).

QT Creator users (@Sould32) should install the QT Creator plugin, available from editorconfig [here](https://github.com/editorconfig/editorconfig-qtcreator).