### PR TITLE
Fix UART test cases

### DIFF
--- a/board_common/common/uart.h
+++ b/board_common/common/uart.h
@@ -56,6 +56,11 @@ typedef enum uart_baud_rate {
 typedef struct uart uart_t;
 
 /**
+ * Open a connection to a UART channel
+ */
+bool uart_open(uart_t * out, size_t baud_rate);
+
+/**
  * Close a connection to a UART channel
  */
 void uart_close(uart_t * out);

--- a/board_common/test/uart.cpp
+++ b/board_common/test/uart.cpp
@@ -6,6 +6,8 @@ TEST_CASE("Test UART implementation can push bytes", "[uart]") {
     uart_t t;
     uint8_t test_data[3] = { 0x02, 0x03, 0x04 };
 
+    uart_open(&t, 9600);
+
     REQUIRE(uart_write_byte(&t, 0x01) == UART_NO_ERROR);
     REQUIRE(uart_write_bytes(&t, test_data, 3) == UART_NO_ERROR);
 

--- a/data_board/test/lithium.cpp
+++ b/data_board/test/lithium.cpp
@@ -5,6 +5,7 @@
 TEST_CASE("The radio interface can send noops", "[data_board][lithium]") {
     lithium_t t;
     uart_t uart;
+    uart_open(&uart, 9600);
     lithium_open(&t, &uart);
 
     REQUIRE(lithium_send_noop(&t) == LITHIUM_NO_ERROR);


### PR DESCRIPTION
The test cases introduced in #11 are missing a call to `uart_open`.