### PR TITLE
Build system tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: bobtwinkles/usip-cci-image:0.0.2
+    steps:
+      - checkout
+      - run:
+          name: Perform a host build
+          command: |
+            mkdir -p /tmp/build
+            cd /tmp/build
+            cmake3 -G "Ninja" /root/project
+            ninja-build -v
+            ./usip_test
+          environment:
+            CC: clang
+            CXX: clang++

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+RUN yum install -y epel-release; yum clean all;
+RUN yum install -y clang cmake3 ninja-build; yum clean all; rm -rf /var/cache/yum
+# We need to install GCC because Clang relies on it under CentOS because reasons
+RUN yum install -y gcc gcc-c++; yum clean all; rm -rf /var/cache/yum

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ project(VT_USIP_FLIGHT_SOFTWARE LANGUAGES C)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(usip_macros)
 
+# We always want C/c++11
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # third-party libraries
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/3rdparty")
 
@@ -55,7 +61,7 @@ add_subdirectory(board_common)
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL msp430)
   # For msp430 builds, use LTO with size optimization
   # We use GCC flag syntax here since we always know we're using msp430-elf-gcc
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -flto -fno-use-linker-plugin -Os")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto -fno-use-linker-plugin -Os")
   message(STATUS "Performing MSP430 build")
   add_definitions(-DUSIP_NATIVE)
   include_directories(board_common/native)
@@ -86,8 +92,6 @@ else()
   message(STATUS "Building test binary")
   # Require C++11
   enable_language(CXX)
-  set(CMAKE_CXX_STANDARD 11)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
   add_subdirectory(data_board)
   add_subdirectory(dev_board)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ add_subdirectory(board_common)
 
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL msp430)
   # For msp430 builds, use LTO with size optimization
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto -fno-use-linker-plugin -Os")
+  # We use GCC flag syntax here since we always know we're using msp430-elf-gcc
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -flto -fno-use-linker-plugin -Os")
   message(STATUS "Performing MSP430 build")
   add_definitions(-DUSIP_NATIVE)
   include_directories(board_common/native)
@@ -81,9 +82,13 @@ if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL msp430)
   # freertos build
   add_subdirectory("3rdparty/freertos/")
 else()
-  message(STATUS "Building test binary")
   # test build
+  message(STATUS "Building test binary")
+  # Require C++11
   enable_language(CXX)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
   add_subdirectory(data_board)
   add_subdirectory(dev_board)
   add_subdirectory(sensor_board)

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ do
       cmake_args='-DUSIP_DATA_BOARD=TRUE -DMSP430_MCU=msp430f5438a'
       ;;
     dev-board)
-      cmake_args='-DUSIP_DEV_BOARD=TRUE -DMSP430_MCU=msp430fr5969'
+      cmake_args='-DUSIP_DEV_BOARD=TRUE -DMSP430_MCU=msp430fr5994'
       ;;
     sensor-board)
       cmake_args='-DUSIP_SENSOR_BOARD=TRUE -DMSP430_MCU=msp430fr5849'

--- a/cmake/custom_toolchains/msp430.cmake
+++ b/cmake/custom_toolchains/msp430.cmake
@@ -43,7 +43,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 # set some default flags
-set(CMAKE_C_FLAGS_INIT   "--std=gnu99 ${_C_FAMILY_FLAGS_INIT}")
+set(CMAKE_C_FLAGS_INIT   "${_C_FAMILY_FLAGS_INIT}")
 
 set(CMAKE_ASM_FLAGS_INIT "${_DISABLE_EXCEPTIONS_FLAGS} ${_M_OPTIONS}")
 


### PR DESCRIPTION
  - Ensures we're always using C++11 for host builds
  - Always use `gnu99` for native builds
  - Use the FR5994 as the dev board target.