### PR TITLE
Implement the Lithium radio (try #2)

### DIFF
--- a/board_common/test/impl/uart_test.cpp
+++ b/board_common/test/impl/uart_test.cpp
@@ -30,7 +30,7 @@ std::ostream & operator<<(std::ostream & o, const uart_t & t) {
 }
 
 std::ostream & operator<<(std::ostream & o, const uart_error_t & err) {
-    o << uart_error_string(err);
+    return o << uart_error_string(err);
 }
 
 /******************************************************************************\
@@ -66,6 +66,22 @@ uart_error_t uart_read_byte(uart_t * channel, uint8_t * output) {
     }
     *output = channel->_impl->input.back();
     channel->_impl->input.pop_back();
+
+    return UART_NO_ERROR;
+}
+
+
+uart_error_t uart_read_bytes(uart_t * channel, uint8_t * bytes, size_t n) {
+    if (!channel->_impl || !channel->_impl->open) {
+        return UART_CHANNEL_CLOSED;
+    }
+    if (channel->_impl->input.size() < n) {
+        return UART_SIGNAL_FAULT;
+    }
+    for (auto i = 0; i < n; ++i, ++bytes) {
+        *bytes = channel->_impl->input.back();
+        channel->_impl->input.pop_back();
+    }
 
     return UART_NO_ERROR;
 }

--- a/data_board/common/lithium.c
+++ b/data_board/common/lithium.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "lithium.h"
 
 #include "lithium_internal.h"
@@ -5,32 +6,235 @@
 /******************************************************************************\
  *  Private support functions                                                 *
 \******************************************************************************/
-void compute_checksum(uint8_t * data, size_t len, uint8_t * output);
-lithium_result_t lithium_send_header(lithium_t * radio, uint8_t command, uint16_t size);
+void compute_checksum(uint8_t * data, size_t length, uint8_t * output);
+uint16_t encode_header(lithium_command_type_t type, lithium_command_t command, uint16_t payload_length, uint8_t * raw_packet);
+uint16_t encode_body(void * payload, uint16_t length, uint8_t * raw_packet);
+lithium_result_t send_data(lithium_t * radio, uint8_t * raw_packet, uint16_t length);
 
 /******************************************************************************\
  *  Pulic interface implementations                                           *
 \******************************************************************************/
-bool lithium_open(lithium_t * out, uart_t * uart) {
-    out->uart = *uart;
+
+bool lithium_open(lithium_t * radio, uart_t * uart) {
+    radio->uart = *uart;
     return true;
 }
 
-void lithium_close(lithium_t * out) {
-    uart_close(&out->uart);
+void lithium_close(lithium_t * radio) {
+    uart_close(&radio->uart);
 }
 
-lithium_result_t lithium_send_noop(lithium_t * radio) {
-    return lithium_send_header(radio, NO_OP_COMMAND, 0);
+
+lithium_result_t lithium_send_packet(lithium_t * radio, lithium_packet_t * packet) {
+    // Encode the header and payload into a buffer
+    uint8_t raw_packet[MAX_PACKET_LENGTH];
+    uint16_t packet_length = encode_header(packet->type, packet->command, packet->payload_length, raw_packet);
+    if (packet->payload_length > 0) {
+        packet_length += encode_body(packet->payload, packet->payload_length, raw_packet);
+    }
+
+    // Send the buffer
+    return send_data(radio, raw_packet, packet_length);
+}
+
+
+// Generate methods to send header-only packets
+#define EMIT_SEND(name, command) \
+    lithium_result_t lithium_send_##name(lithium_t * radio) { \
+        uint8_t raw_packet[HEADER_LENGTH]; \
+        uint16_t packet_length = encode_header(LITHIUM_I_MESSAGE, LITHIUM_COMMAND_##command, 0, raw_packet); \
+        return send_data(radio, raw_packet, packet_length); \
+    }
+
+EMIT_SEND(no_op, NO_OP)
+EMIT_SEND(reset, RESET_SYSTEM)
+EMIT_SEND(get_config, GET_TRANSCEIVER_CONFIG)
+EMIT_SEND(query_telem, TELEMETRY_QUERY)
+EMIT_SEND(read_fw_version, READ_FIRMWARE_REVISION)
+
+#undef EMIT_SEND
+
+
+// Generate methods to send packets with payloads
+#define EMIT_SEND_PAYLOAD(name, command, data_param, length_param, ...) \
+    lithium_result_t lithium_send_##name(lithium_t * radio, __VA_ARGS__) {\
+        uint8_t raw_packet[MAX_PACKET_LENGTH]; \
+        uint16_t packet_length = encode_header(LITHIUM_I_MESSAGE, LITHIUM_COMMAND_##command, length_param, raw_packet); \
+        packet_length +=  encode_body(data_param, length_param, raw_packet); \
+        return send_data(radio, raw_packet, packet_length); \
+    }
+
+EMIT_SEND_PAYLOAD(transmit, TRANSMIT_DATA,
+    data, length,
+    uint8_t * data, uint16_t length)
+EMIT_SEND_PAYLOAD(set_config, SET_TRANSCEIVER_CONFIG,
+    config, sizeof(lithium_config_t),
+    lithium_config_t * config)
+EMIT_SEND_PAYLOAD(write_flash, WRITE_FLASH,
+    hash, 16,
+    uint8_t * hash)
+EMIT_SEND_PAYLOAD(set_rf_config, RF_CONFIG,
+    config, sizeof(lithium_rf_config_t),
+    lithium_rf_config_t * config)
+EMIT_SEND_PAYLOAD(set_beacon, BEACON_DATA,
+    data, length,
+    uint8_t * data, uint16_t length)
+EMIT_SEND_PAYLOAD(set_beacon_config, BEACON_CONFIG,
+    config, sizeof(lithium_beacon_config_t),
+    lithium_beacon_config_t * config)
+EMIT_SEND_PAYLOAD(write_dio_key, WRITE_OVER_AIR_KEY,
+    key, 16,
+    uint8_t * key)
+EMIT_SEND_PAYLOAD(begin_fw_update, FIRMWARE_UPDATE,
+    hash, 16,
+    uint8_t * hash)
+EMIT_SEND_PAYLOAD(stream_fw_update, FIRMWARE_PACKET,
+    data, length,
+    uint8_t * data, uint16_t length)
+EMIT_SEND_PAYLOAD(set_pa_level, FAST_PA_SET,
+    &speed, 1,
+    uint8_t speed)
+
+#undef EMIT_SEND_PAYLOAD
+
+
+lithium_result_t lithium_receive_packet(lithium_t * radio, lithium_packet_t * packet) {
+    // Try to read a header
+    uint8_t raw_packet[MAX_PACKET_LENGTH];
+    uart_error_t uart_err = uart_read_bytes(&radio->uart, raw_packet, HEADER_LENGTH);
+    if (uart_err != UART_NO_ERROR) {
+        return LITHIUM_BAD_COMMUNICATION;
+    }
+
+    // Parse the header and see if there's a payload
+    uint16_t remaining_bytes;
+    lithium_result_t err = lithium_parse_header(raw_packet, packet, &remaining_bytes);
+    if (err != LITHIUM_NO_ERROR) {
+        return err;
+    }
+
+    // Try to read a payload
+    if (remaining_bytes > 0) {
+        uart_err = uart_read_bytes(&radio->uart, raw_packet + HEADER_LENGTH, remaining_bytes);
+        if (uart_err != UART_NO_ERROR) {
+            return LITHIUM_BAD_COMMUNICATION;
+        }
+
+        err = lithium_parse_body(raw_packet, packet);
+        if (err != LITHIUM_NO_ERROR) {
+            return err;
+        }
+    }
+
+    return LITHIUM_NO_ERROR;
+}
+
+
+lithium_result_t lithium_parse_header(uint8_t * raw_packet, lithium_packet_t * packet, uint16_t * remaining_bytes) {
+    // Validate magic bytes
+    bool has_sync_bytes = (raw_packet[0] == SYNC_1 && raw_packet[1] == SYNC_2);
+    if (!has_sync_bytes) {
+        return LITHIUM_INVALID_PACKET;
+    }
+
+    lithium_command_type_t type = raw_packet[2];
+    lithium_command_t command = raw_packet[3];
+
+    // Validate command
+    bool is_valid_message_type = (type == LITHIUM_I_MESSAGE || type == LITHIUM_O_MESSAGE);
+    bool is_valid_command = (command < LITHIUM_COMMAND_count);
+    if (!is_valid_message_type || !is_valid_command) {
+        return LITHIUM_INVALID_PACKET;
+    }
+
+    uint16_t payload_length = (raw_packet[4] << 8) | raw_packet[5];
+
+    // Validate payload length
+    bool is_ack_nack_packet = (
+        type == LITHIUM_O_MESSAGE &&
+        (payload_length == ACK_LENGTH || payload_length == NACK_LENGTH));
+    bool has_valid_payload_size = (payload_length <= MAX_PAYLOAD_LENGTH);
+    if (!is_ack_nack_packet && !has_valid_payload_size) {
+        return LITHIUM_INVALID_PACKET;
+    }
+
+    uint8_t header_checksum[CHECKSUM_LENGTH];
+    compute_checksum(raw_packet + SYNC_BYTES_LENGTH, HEADER_DATA_LENGTH, header_checksum);
+
+    // Validate header checksums
+    bool header_checksums_match = (
+        raw_packet[6] == header_checksum[0] &&
+        raw_packet[7] == header_checksum[1]);
+    if (!header_checksums_match) {
+        return LITHIUM_INVALID_CHECKSUM;
+    }
+
+    // Indicate the number of bytes to read for a body
+    if (!is_ack_nack_packet && payload_length > 0) {
+        *remaining_bytes = payload_length + CHECKSUM_LENGTH;
+    }
+    else {
+        *remaining_bytes = 0;
+    }
+
+    // Populate remaining fields
+    packet->type = type;
+    packet->command = command;
+    packet->payload_length = payload_length;
+
+    return LITHIUM_NO_ERROR;
+}
+
+lithium_result_t lithium_parse_body(uint8_t * raw_packet, lithium_packet_t * packet) {
+    uint16_t payload_length = packet->payload_length;
+    uint8_t payload_checksum[CHECKSUM_LENGTH];
+    compute_checksum(raw_packet + SYNC_BYTES_LENGTH, HEADER_DATA_LENGTH + CHECKSUM_LENGTH + payload_length, payload_checksum);
+
+    // Validate payload checksums
+    bool payload_checksums_match = (
+        raw_packet[HEADER_LENGTH+payload_length] == payload_checksum[0] &&
+        raw_packet[HEADER_LENGTH+payload_length+1] == payload_checksum[1]);
+    if (!payload_checksums_match) {
+        return LITHIUM_INVALID_CHECKSUM;
+    }
+
+    // Copy payload
+    memcpy(packet->payload, raw_packet + HEADER_LENGTH, payload_length);
+
+    return LITHIUM_NO_ERROR;
+}
+
+
+bool lithium_is_i_message(lithium_packet_t * packet) {
+    return packet->type == LITHIUM_I_MESSAGE;
+}
+
+bool lithium_is_o_message(lithium_packet_t * packet) {
+    return packet->type == LITHIUM_O_MESSAGE;
+}
+
+bool lithium_is_ack(lithium_packet_t * packet) {
+    return packet->type == LITHIUM_O_MESSAGE && packet->payload_length == ACK_LENGTH;
+}
+
+bool lithium_is_nack(lithium_packet_t * packet) {
+    return packet->type == LITHIUM_O_MESSAGE && packet->payload_length == NACK_LENGTH;
 }
 
 /******************************************************************************\
  *  Private support function implementations                                  *
 \******************************************************************************/
-void compute_checksum(uint8_t * data, size_t len, uint8_t * output) {
+/**
+ * Calculate the Fletcher-16 checksum of binary data
+ *
+ * @param data The data to calculate the checksum of
+ * @param length The length of the data
+ * @param output The 2-byte checksum output
+ */
+void compute_checksum(uint8_t * data, size_t length, uint8_t * output) {
     uint8_t a = 0;
     uint8_t b = 0;
-    for (size_t i = 0; i < len; ++i) {
+    for (size_t i = 0; i < length; ++i) {
         a += data[i];
         b += a;
     }
@@ -38,19 +242,56 @@ void compute_checksum(uint8_t * data, size_t len, uint8_t * output) {
     output[1] = b;
 }
 
-lithium_result_t lithium_send_header(lithium_t * radio, uint8_t command, uint16_t size) {
-    uint8_t header[8];
-    header[0] = 0x48; // 'H'
-    header[1] = 0x65; // 'E'
-    header[2] = 0x10;
-    header[3] = command;
-    header[4] = (size >> 8) & 0xFF;
-    header[5] = size & 0xFF;
-    compute_checksum(header, 6, header + 6);
+/**
+ * Encode a Lithium packet's header
+ *
+ * @param type The type of the packet
+ * @param command The packet's command
+ * @param payload_length The length of the packet's payload
+ * @param raw_packet The output byte array of at least 8 bytes
+ *
+ * @return The size of the packet header in bytes
+ */
+uint16_t encode_header(lithium_command_type_t type, lithium_command_t command, uint16_t payload_length, uint8_t * raw_packet) {
+    raw_packet[0] = SYNC_1;
+    raw_packet[1] = SYNC_2;
+    raw_packet[2] = type;
+    raw_packet[3] = command;
+    raw_packet[4] = (payload_length >> 8) & 0xFF;
+    raw_packet[5] = payload_length & 0xFF;
+    compute_checksum(raw_packet + 2, 4, raw_packet + 6);
+    return 8;
+}
 
-    uart_error_t err = uart_write_bytes(&radio->uart, header, 8);
+/**
+ * Encode a Lithium packet's body, assuming the header already exists
+ *
+ * @param payload The payload to encode
+ * @param length The length of the payload
+ * @param raw_packet The output byte array of at least 265 bytes
+ *
+ * @return The size of the packet body in bytes
+ */
+uint16_t encode_body(void * payload, uint16_t length, uint8_t * raw_packet) {
+    memcpy(raw_packet + 8, payload, length);
+    compute_checksum(raw_packet + 2, 6 + length, raw_packet + 8 + length);
+    return length + 2;
+}
+
+/**
+ * Send a byte array through the UART channel associated with a radio
+ *
+ * @param radio The radio instance owning the UART channel
+ * @param raw_packet The data to send
+ * @param length The length of the data to send
+ *
+ * @return The result of the operation
+ */
+lithium_result_t send_data(lithium_t * radio, uint8_t * raw_packet, uint16_t length) {
+    uart_error_t err = uart_write_bytes(&radio->uart, raw_packet, length);
     if (err != UART_NO_ERROR) {
         return LITHIUM_BAD_COMMUNICATION;
     }
+
     return LITHIUM_NO_ERROR;
 }

--- a/data_board/common/lithium.h
+++ b/data_board/common/lithium.h
@@ -8,11 +8,24 @@ extern "C" {
 #endif
 
 /**
+ * The connection to a Lithium radio
+ */
+typedef struct lithium {
+    /**
+     * The owned UART channel over which we talk
+     */
+    uart_t uart;
+} lithium_t;
+
+
+/**
  * Macro list for results of operations on the Lithium
  */
 #define LITHIUM_RESULT_LIST(OP) \
     OP(NO_ERROR) \
-    OP(BAD_COMMUNICATION)
+    OP(BAD_COMMUNICATION) \
+    OP(INVALID_PACKET) \
+    OP(INVALID_CHECKSUM)
 
 /**
  * Enumeration of possible results for trying to communicate with the Lithium
@@ -24,43 +37,437 @@ typedef enum lithium_result {
     LITHIUM_count
 } lithium_result_t;
 
+#undef LITHIUM_RESULT_LIST
+
 
 /**
- * Represents a connection to a Lithium radio
+ * Macro list for the types of a Lithium packet
  */
-typedef struct lithium {
-    /**
-     * The UART channel over which we talk
-     */
-    uart_t uart;
-} lithium_t;
+#define LITHIUM_COMMAND_TYPE_LIST(TYPE) \
+    TYPE(I_MESSAGE, 0x10) \
+    TYPE(O_MESSAGE, 0x20)
 
 /**
- * Open a connection to a Lithium radio.
+ * Enumeration of the types of Lithium packets
+ */
+typedef enum lithium_command_type {
+#   define STRING_OP(E, V) LITHIUM_##E = V,
+    LITHIUM_COMMAND_TYPE_LIST(STRING_OP)
+#   undef STRING_OP
+} lithium_command_type_t;
+
+#undef LITHIUM_COMMAND_TYPE_LIST
+
+/**
+ * Macro list for the types of Lithium commands
+ */
+#define LITHIUM_COMMAND_LIST(COMMAND) \
+    COMMAND(NO_OP, 0x01) \
+    COMMAND(RESET_SYSTEM, 0x02) \
+    COMMAND(TRANSMIT_DATA, 0x03) \
+    COMMAND(RECEIVE_DATA, 0x04) \
+    COMMAND(GET_TRANSCEIVER_CONFIG, 0x05) \
+    COMMAND(SET_TRANSCEIVER_CONFIG, 0x06) \
+    COMMAND(TELEMETRY_QUERY, 0x07) \
+    COMMAND(WRITE_FLASH, 0x08) \
+    COMMAND(RF_CONFIG, 0x09) \
+    COMMAND(BEACON_DATA, 0x10) \
+    COMMAND(BEACON_CONFIG, 0x11) \
+    COMMAND(READ_FIRMWARE_REVISION, 0x12) \
+    COMMAND(WRITE_OVER_AIR_KEY, 0x13) \
+    COMMAND(FIRMWARE_UPDATE, 0x14) \
+    COMMAND(FIRMWARE_PACKET, 0x15) \
+    COMMAND(FAST_PA_SET, 0x20)
+
+/**
+ * Enumeration for the types of Lithium commands
+ */
+typedef enum lithium_command {
+#   define STRING_OP(E, V) LITHIUM_COMMAND_##E = V,
+    LITHIUM_COMMAND_LIST(STRING_OP)
+#   undef STRING_OP
+    LITHIUM_COMMAND_count
+} lithium_command_t;
+
+#undef LITHIUM_COMMAND_LIST
+
+/**
+ * Macro list for UART baud rates
+ */
+#define LITHIUM_BAUD_LIST(BAUD) \
+    BAUD(9600, 0) \
+    BAUD(19200, 1) \
+    BAUD(38400, 2) \
+    BAUD(76800, 3) \
+    BAUD(115200, 4)
+
+/**
+ * Enumeration for the UART baud rates used in the front-end configuration
+ */
+typedef enum lithium_baud {
+#   define STRING_OP(E, V) LITHIUM_BAUD_##E = V,
+    LITHIUM_BAUD_LIST(STRING_OP)
+#   undef STRING_OP
+} lithium_baud_t;
+
+#undef LITHIUM_BAUD_LIST
+
+/**
+ * Macro list for the RF baud rates
+ */
+#define LITHIUM_RF_BAUD_LIST(BAUD) \
+    BAUD(1200, 0) \
+    BAUD(9600, 1) \
+    BAUD(19200, 2) \
+    BAUD(38400, 3)
+
+/**
+ * Enumeration for the RF baud rates used in the RF configuration
+ */
+typedef enum lithium_rf_baud {
+#   define STRING_OP(E, V) LITHIUM_RF_BAUD_##E = V,
+    LITHIUM_RF_BAUD_LIST(STRING_OP)
+#   undef STRING_OP
+} lithium_rf_baud_t;
+
+#undef LITHIUM_RF_BAUD_LIST
+
+/**
+ * Macro list for the RF modulation methods
+ */
+#define LITHIUM_RF_MOD_LIST(MOD) \
+    MOD(GFSK, 0) \
+    MOD(AFSK, 1) \
+    MOD(BPSK, 2)
+
+/**
+ * Enumeration for the RF modulation methods used in the RF configuration
+ */
+typedef enum lithium_rf_mod {
+#   define STRING_OP(E, V) LITHIUM_RF_MOD_##E = V,
+    LITHIUM_RF_MOD_LIST(STRING_OP)
+#   undef STRING_OP
+} lithium_rf_mod_t;
+
+#undef LITHIUM_RF_MOD_LIST
+
+/**
+ * The packet representation used to communicate with a Lithium radio
+ */
+typedef struct lithium_packet {
+    /**
+     * The type of the packet, either to (I-Message) or from (O-Message) the
+     * radio
+     */
+    lithium_command_type_t type;
+    /**
+     * The command of the packet
+     */
+    lithium_command_t command;
+    /**
+     * The length of the payload, also used to indicate ACK/NACK in O-Messages
+     */
+    uint16_t payload_length;
+    /**
+     * The packet's payload
+     */
+    uint8_t payload[255];
+} lithium_packet_t;
+
+
+/**
+ * The front-end configuration of a Lithium radio
+ */
+typedef struct lithium_config {
+    lithium_baud_t interface_baud_rate;   //Radio Interface Baud Rate (9600=0x00)
+    uint8_t tx_power_amp_level;    //Tx Power Amp level (min = 0x00 max = 0xFF)
+    lithium_rf_baud_t rx_rf_baud_rate;       //Radio RX RF Baud Rate (9600=0x00)
+    lithium_rf_baud_t tx_rf_baud_rate;       //Radio TX RF Baud Rate (9600=0x00)
+    lithium_rf_mod_t rx_modulation;         //(0x00 = GFSK);
+    lithium_rf_mod_t tx_modulation;         //(0x00 = GFSK);
+    uint32_t rx_freq;               //Channel Rx Frequency (ex: 45000000)
+    uint32_t tx_freq;               //Channel Tx Frequency (ex: 45000000)
+    unsigned char source[6];      //AX25 Mode Source Call Sign (default NOCALL)
+    unsigned char destination[6]; //AX25 Mode Destination Call Sign (default CQ)
+    uint16_t tx_preamble;           //AX25 Mode Tx Preamble Byte Length (0x00 = 20 flags)
+    uint16_t tx_postamble;          //AX25 Mode Tx Postamble Byte Length (0x00 = 20 flags)
+    uint16_t function_config;       //Radio Configuration Discrete Behaviors
+    uint16_t function_config2;    //Radio Configuration Discrete Behaviors #2
+} lithium_config_t;
+
+/**
+ * The configuration of a Lithium's RF module
+ */
+typedef struct lithium_rf_config {
+    uint8_t front_end_level; //0 to 63 Value
+    uint8_t tx_power_amp_level; //0 to 255 value, non-linear
+    uint32_t tx_frequency_offset; //Up to 20 kHz
+    uint32_t rx_frequency_offset; //Up to 20 kHz
+} lithium_rf_config_t;
+
+/**
+ * The configuration of a Lithium's beacon system
+ */
+typedef struct lithium_beacon_config {
+    uint8_t beacon_interval;  //value of 0 is off, 2.5 sec delay per LSB
+} lithium_beacon_config_t;
+
+/**
+ * The telemetry packet describing the radio's status
+ */
+typedef struct lithium_telem {
+    uint16_t op_counter;
+    int16_t msp430_temp;
+    uint8_t time_count[3];
+    uint8_t rssi;
+    uint32_t bytes_received;
+    uint32_t bytes_transmitted;
+} lithium_telem_t;
+
+
+/**
+ * Open a connection to a Lithium radio
  *
- * @param out Output parameter
+ * @param radio The output radio object
  * @param uart The UART channel to use. Takes ownership of the lifecycle of this
  *      channel
  *
  * @return True if and only if the radio connection succeeds
  */
-bool lithium_open(lithium_t * out, uart_t * uart);
+bool lithium_open(lithium_t * radio, uart_t * uart);
 
 /**
- * Close a connection to a lithium radio.
+ * Close a connection to a Lithium radio
  *
  * @param radio The radio to close
  */
-void lithium_close(lithium_t * out);
+void lithium_close(lithium_t * radio);
 
 /**
- * Send a noop command to an open lithium radio
+ * Send a packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param packet The packet to send
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_packet(lithium_t * radio, lithium_packet_t * packet);
+
+/**
+ * Send a no-operation packet to a Lithium radio
  *
  * @param radio The radio to communicate with
  *
- * @return LITHIUM_OK if and only if communication succeeds.
+ * @return The result of the operation
  */
-lithium_result_t lithium_send_noop(lithium_t * radio);
+lithium_result_t lithium_send_no_op(lithium_t * radio);
+
+/**
+ * Send a system reset packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_reset(lithium_t * radio);
+
+/**
+ * Send a data transmission packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param data The transmission payload to send
+ * @param length The length of the transmission payload
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_transmit(lithium_t * radio, uint8_t * data, uint16_t length);
+
+/**
+ * Send a radio configuration request packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_get_config(lithium_t * radio);
+
+/**
+ * Send a radio configuration change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param config The configuration to set the radio to
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_set_config(lithium_t * radio, lithium_config_t * config);
+
+/**
+ * Send a telemetry query packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_query_telem(lithium_t * radio);
+
+/**
+ * Send a radio configuration write-to-flash packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param hash The 16 byte MD5 hash of the radio configuration
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_write_flash(lithium_t * radio, uint8_t * hash);
+
+/**
+ * Send an RF configuration change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param config The configuration to send to the RF module
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_set_rf_config(lithium_t * radio, lithium_rf_config_t * config);
+
+/**
+ * Send a beacon data change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param data The contents of the beacon
+ * @param length The length of the beacon contents
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_set_beacon(lithium_t * radio, uint8_t * data, uint16_t length);
+
+/**
+ * Send a beacon configuration change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param config The configuration to send to the beacon module
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_set_beacon_config(lithium_t * radio, lithium_beacon_config_t * config);
+
+/**
+ * Send a firmware version request packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_read_fw_version(lithium_t * radio);
+
+/**
+ * Send an over-the-air key change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param key The 4 byte key to change to
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_write_dio_key(lithium_t * radio, uint8_t * key);
+
+/**
+ * Send a firmware update initiation packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param hash The 16 byte MD5 hash of the firmware update
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_begin_fw_update(lithium_t * radio, uint8_t * hash);
+
+/**
+ * Send a firmware update chunk packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param data The chunk of the firmware update
+ * @param length The length of the chunk
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_stream_fw_update(lithium_t * radio, uint8_t * data, uint16_t length);
+
+/**
+ * Send a power amplifier level change packet to a Lithium radio
+ *
+ * @param radio The radio to communicate with
+ * @param speed The speed to change the power amplifier level to
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_send_set_pa_level(lithium_t * radio, uint8_t speed);
+
+/**
+ * Attempt to receive and parse a Lithium packet over the UART channel
+ *
+ * @param radio The radio to communicate with
+ * @param packet The output packet parsed from the channel
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_receive_packet(lithium_t * radio, lithium_packet_t * packet);
+
+/**
+ * Parse the header of an encoded Lithium packet
+ *
+ * @param raw_packet The encoded packet header to parse
+ * @param packet The output packet with header fields populated
+ * @param remaining_bytes The output number of bytes to read to parse a body
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_parse_header(uint8_t * raw_packet, lithium_packet_t * packet, uint16_t * remaining_bytes);
+
+/**
+ * Parse the body of an encoded Lithium packet
+ *
+ * @param raw_packet The entire encoded packet to parse
+ * @param packet The completed output packet
+ *
+ * @return The result of the operation
+ */
+lithium_result_t lithium_parse_body(uint8_t * raw_packet, lithium_packet_t * packet);
+
+/**
+ * Check if a packet is an I-Message
+ *
+ * @param packet The packet to inspect
+ *
+ * @return True if packet is an I-Message
+ */
+bool lithium_is_i_message(lithium_packet_t * packet);
+
+/**
+ * Check if a packet is an O-Message
+ *
+ * @param packet The packet to inspect
+ *
+ * @return True if packet is an O-Message
+ */
+bool lithium_is_o_message(lithium_packet_t * packet);
+
+/**
+ * Check if a packet is indicating an acknowledgement (ACK)
+ *
+ * @param packet The packet to inspect
+ *
+ * @return True if packet is an I-Message
+ */
+bool lithium_is_ack(lithium_packet_t * packet);
+
+/**
+ * Check if a packet is indicating a non-acklowedgement (NACK)
+ *
+ * @param packet The packet to inspect
+ *
+ * @return True if packet has the size of a NACK packet
+ */
+bool lithium_is_nack(lithium_packet_t * packet);
+
 
 #ifdef __cplusplus
 }

--- a/data_board/common/lithium.h
+++ b/data_board/common/lithium.h
@@ -395,11 +395,11 @@ lithium_result_t lithium_send_stream_fw_update(lithium_t * radio, uint8_t * data
  * Send a power amplifier level change packet to a Lithium radio
  *
  * @param radio The radio to communicate with
- * @param speed The speed to change the power amplifier level to
+ * @param output_level The power output level to change the power amplifier to
  *
  * @return The result of the operation
  */
-lithium_result_t lithium_send_set_pa_level(lithium_t * radio, uint8_t speed);
+lithium_result_t lithium_send_set_pa_level(lithium_t * radio, uint8_t output_level);
 
 /**
  * Attempt to receive and parse a Lithium packet over the UART channel
@@ -420,7 +420,7 @@ lithium_result_t lithium_receive_packet(lithium_t * radio, lithium_packet_t * pa
  *
  * @return The result of the operation
  */
-lithium_result_t lithium_parse_header(uint8_t * raw_packet, lithium_packet_t * packet, uint16_t * remaining_bytes);
+lithium_result_t lithium_parse_header(uint8_t * raw_packet, uint16_t raw_packet_length, lithium_packet_t * packet, uint16_t * remaining_bytes);
 
 /**
  * Parse the body of an encoded Lithium packet
@@ -430,7 +430,7 @@ lithium_result_t lithium_parse_header(uint8_t * raw_packet, lithium_packet_t * p
  *
  * @return The result of the operation
  */
-lithium_result_t lithium_parse_body(uint8_t * raw_packet, lithium_packet_t * packet);
+lithium_result_t lithium_parse_body(uint8_t * raw_packet, uint16_t raw_packet_length, lithium_packet_t * packet);
 
 /**
  * Check if a packet is an I-Message

--- a/data_board/common/lithium_internal.h
+++ b/data_board/common/lithium_internal.h
@@ -26,11 +26,11 @@
 // Length of the header/payload checksum bytes
 #define CHECKSUM_LENGTH     2
 // Length of all of the header bytes
-#define HEADER_LENGTH       SYNC_BYTES_LENGTH + HEADER_DATA_LENGTH + CHECKSUM_LENGTH
+#define HEADER_LENGTH       (SYNC_BYTES_LENGTH + HEADER_DATA_LENGTH + CHECKSUM_LENGTH)
 // Maximum length of the payload
 #define MAX_PAYLOAD_LENGTH  255
 // Maximum length of the entire packet
-#define MAX_PACKET_LENGTH   HEADER_LENGTH + MAX_PAYLOAD_LENGTH + CHECKSUM_LENGTH
+#define MAX_PACKET_LENGTH   (HEADER_LENGTH + MAX_PAYLOAD_LENGTH + CHECKSUM_LENGTH)
 
 /**
  * Over-the-air commands

--- a/data_board/common/lithium_internal.h
+++ b/data_board/common/lithium_internal.h
@@ -1,36 +1,40 @@
-//Configuration Commands
-#define NO_OP_COMMAND           0x01
-#define RESET_SYSTEM            0x02
-#define TRANSMIT_DATA           0x03
-#define RECEIVE_DATA            0x04
-#define GET_TRANSCEIVER_CONFIG  0x05
-#define SET_TRANSCEIVER_CONFIG  0x06
-#define TELEMETRY_QUERY         0x07
-#define WRITE_FLASH             0x08
-#define RF_CONFIG               0x09
-#define BEACON_DATA             0x10
-#define BEACON_CONFIG           0x11
-#define READ_FIRMWARE_REVISION  0x12
-#define WRITE_OVER_AIR_KEY      0x13
-#define FIRMWARE_UPDATE         0x14
-#define FIRMWARE_PACKET         0x15
-#define FAST_PA_SET             0x20
+/**
+ * Packet intrinsics
+ */
 
-#define BAUD_RATE_9600      0
-#define BAUD_RATE_19200     1
-#define BAUD_RATE_38400     2
-#define BAUD_RATE_76800     3
-#define BAUD_RATE_115200    4
+// First packet header magic byte
+#define SYNC_1 'H'
+// Second packet header magic byte
+#define SYNC_2 'e'
+// The command type of an I-Message
+#define I_MESSAGE_TYPE 0x10
+// The command type of an O-Message
+#define O_MESSAGE_TYPE 0x20
+// The payload length of an ACK O-Message
+#define ACK_LENGTH    0x0a0a
+// The payload length of a NACK O-Message
+#define NACK_LENGTH   0xffff
 
-#define RF_BAUD_RATE_1200   0
-#define RF_BAUD_RATE_9600   1
-#define RF_BAUD_RATE_19200  2
-#define RF_BAUD_RATE_38400  3
+/**
+ * Upper-bound packet sizes
+ */
 
-#define RF_MODULATION_GFSK  0
-#define RF_MODULATION_AFSK  1
-#define RF_MODULATION_BPSK  2
+// Length of the sync bytes
+#define SYNC_BYTES_LENGTH   2
+// Length of the checksumed command and payload length header bytes
+#define HEADER_DATA_LENGTH  4
+// Length of the header/payload checksum bytes
+#define CHECKSUM_LENGTH     2
+// Length of all of the header bytes
+#define HEADER_LENGTH       SYNC_BYTES_LENGTH + HEADER_DATA_LENGTH + CHECKSUM_LENGTH
+// Maximum length of the payload
+#define MAX_PAYLOAD_LENGTH  255
+// Maximum length of the entire packet
+#define MAX_PACKET_LENGTH   HEADER_LENGTH + MAX_PAYLOAD_LENGTH + CHECKSUM_LENGTH
 
+/**
+ * Over-the-air commands
+ */
 
 #define TELEMETRY_DUMP_COMMAND  0x30
 #define PING_RETURN_COMMAND     0x31

--- a/data_board/test/lithium.cpp
+++ b/data_board/test/lithium.cpp
@@ -3,20 +3,213 @@
 
 #include <catch/catch.hpp>
 
-TEST_CASE("The radio interface can send noops", "[data_board][lithium]") {
+// Set the input of the mock UART
+#define SET_UART_INPUT(t, ...) \
+    do { \
+        t.uart._impl->input = { __VA_ARGS__ }; \
+        std::reverse(t.uart._impl->input.begin(), t.uart._impl->input.end()); \
+    } while (0)
+
+// Check if a packet's payload has matching bytes
+#define REQUIRE_PAYLOAD_HAS_BYTES(packet, ...) \
+    do { \
+        std::vector<uint8_t> vec(packet.payload, packet.payload + packet.payload_length); \
+        REQUIRE(vec == std::vector<uint8_t>({ __VA_ARGS__ })); \
+    } while (0)
+
+
+TEST_CASE("The radio interface can handle no ops", "[data_board][lithium]") {
     lithium_t t;
     uart_t uart;
     uart_open(&uart, 9600);
     lithium_open(&t, &uart);
 
-    REQUIRE(lithium_send_noop(&t) == LITHIUM_NO_ERROR);
+    SECTION("Write send") {
+        REQUIRE(lithium_send_no_op(&t) == LITHIUM_NO_ERROR);
 
-    REQUIRE_THAT(t.uart, HasWrittenBytes({
-        0x48, 0x65, // Synchronization bytes
-        0x10, 0x01, // Command
-        0x00, 0x00, // Length
-        0xBE, 0xEC  // Checksum
-    }));
+        REQUIRE_THAT(t.uart, HasWrittenBytes({
+            0x48, 0x65,
+            0x10, 0x01,
+            0x00, 0x00,
+            0x11, 0x43,
+        }));
+    }
+
+    SECTION("Parse send") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x10, 0x01,
+            0x00, 0x00,
+            0x11, 0x43,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_I_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_NO_OP);
+        REQUIRE(packet.payload_length == 0);
+    }
+
+    SECTION("Parse ACK receive") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x20, 0x01,
+            0x0a, 0x0a,
+            0x35, 0xa1,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_O_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_NO_OP);
+        REQUIRE(lithium_is_ack(&packet));
+    }
+
+    SECTION("Parse NACK receive") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x20, 0x01,
+            0xff, 0xff,
+            0x1f, 0x80,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_O_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_NO_OP);
+        REQUIRE(lithium_is_nack(&packet));
+    }
+
+    lithium_close(&t);
+}
+
+TEST_CASE("The radio interface can handle transmissions", "[data_board][lithium]") {
+    lithium_t t;
+    uart_t uart;
+    uart_open(&uart, 9600);
+    lithium_open(&t, &uart);
+
+    SECTION("Write send") {
+        uint8_t data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        uint16_t length = 10;
+
+        REQUIRE(lithium_send_transmit(&t, data, length) == LITHIUM_NO_ERROR);
+
+        REQUIRE_THAT(t.uart, HasWrittenBytes({
+            0x48, 0x65,
+            0x10, 0x03,
+            0x00, 0x0a,
+            0x1d, 0x53,
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            0xba, 0x41,
+        }));
+    }
+
+    SECTION("Parse send") {
+        SECTION("Valid") {
+            SET_UART_INPUT(t,
+                0x48, 0x65,
+                0x10, 0x03,
+                0x00, 0x0a,
+                0x1d, 0x53,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0xba, 0x41,
+            );
+
+            lithium_packet_t packet;
+            REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+            REQUIRE(packet.type == LITHIUM_I_MESSAGE);
+            REQUIRE(packet.command == LITHIUM_COMMAND_TRANSMIT_DATA);
+            REQUIRE(packet.payload_length == 10);
+            REQUIRE_PAYLOAD_HAS_BYTES(packet,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            );
+        }
+
+        SECTION("Bad header checksum") {
+            SET_UART_INPUT(t,
+                0x48, 0x65,
+                0x10, 0x03,
+                0x00, 0x0a,
+                0x1e, 0x54,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0xba, 0x41,
+            );
+
+            lithium_packet_t packet;
+            REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_INVALID_CHECKSUM);
+        }
+
+        SECTION("Invalid payload size") {
+            SET_UART_INPUT(t,
+                0x48, 0x65,
+                0x10, 0x03,
+                0x0b, 0x0a,
+                0x9a, 0x49,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0xba, 0x41,
+            );
+
+            lithium_packet_t packet;
+            REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_INVALID_PACKET);
+        }
+    }
+
+    SECTION("Parse ACK receive") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x20, 0x03,
+            0x0a, 0x0a,
+            0x37, 0xa7,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_O_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_TRANSMIT_DATA);
+        REQUIRE(lithium_is_ack(&packet));
+    }
+
+    SECTION("Parse NACK receive") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x20, 0x03,
+            0xff, 0xff,
+            0x21, 0x86,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_O_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_TRANSMIT_DATA);
+        REQUIRE(lithium_is_nack(&packet));
+    }
+
+    SECTION("Parse received data") {
+        SET_UART_INPUT(t,
+            0x48, 0x65,
+            0x20, 0x04,
+            0x00, 0x0a,
+            0x2e, 0x96,
+            10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            0x83, 0x23,
+        );
+
+        lithium_packet_t packet;
+        REQUIRE(lithium_receive_packet(&t, &packet) == LITHIUM_NO_ERROR);
+
+        REQUIRE(packet.type == LITHIUM_O_MESSAGE);
+        REQUIRE(packet.command == LITHIUM_COMMAND_RECEIVE_DATA);
+        REQUIRE_PAYLOAD_HAS_BYTES(packet,
+            10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        );
+    }
 
     lithium_close(&t);
 }


### PR DESCRIPTION
Includes everything from #16 as well as the issues suggested in comments.

> Completes #4 and fully implements communication to and fro the Lithium radio.
> 
> - Packet encoding + sending functions exist for all packet commands.
> - A generic packet decoding routine can be used to parse packets off the wire.
> - A few convenience functions are exposed to analyze packets.
> - All functions and types are reasonably documented.
> - Basic, practical testing is performed of the encoding and decoding routines. 

I would especially recommend verifying that my checksum algorithm is correct, both for the header and payload.